### PR TITLE
Change she-bang to the more portable env

### DIFF
--- a/hook.sh
+++ b/hook.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # If we have a STDIN, use it, otherwise get one
 if tty >/dev/null 2>&1; then


### PR DESCRIPTION
My system doesn't have bash at `/bin/bash`.  This change uses the more portable `/usr/bin/env bash` which will find bash wherever it is installed on the system.